### PR TITLE
Introduce a default abbreviated Code of Conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,35 @@
+# WordPress Community Code of Conduct
+
+The WordPress community welcomes contributors from around the world to help us [Make WordPress](https://make.wordpress.org/) and [Democratize Publishing](https://wordpress.org/about/). This handbook aims to express our shared expectations of how we, as contributors, work together, who we want to build our products for, and the WordPress interpretation of modern, open source best practices.
+
+This includes a [Community Code of Conduct](https://make.wordpress.org/handbook/community-code-of-conduct/) (partially included below) and [Incident Response Team](https://make.wordpress.org/community/handbook/irt/).
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, and inclusive community.
+
+## Our Expectations
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of any kind
+* Insulting or derogatory comments, taunting or baiting, and personal or political attacks
+* Public or private harassment
+* Publishing others’ private information, such as a physical or email address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+The full [Community Code of Conduct](https://make.wordpress.org/handbook/community-code-of-conduct/) can be found in the [Contributor Handbook](https://make.wordpress.org/handbook/).
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org/), version 2.1, available at https://www.contributor-covenant.org/version/2/1/code_of_conduct.html.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,6 +1,6 @@
 # WordPress Community Code of Conduct
 
-The WordPress community welcomes contributors from around the world to help us [Make WordPress](https://make.wordpress.org/) and [Democratize Publishing](https://wordpress.org/about/). This handbook aims to express our shared expectations of how we, as contributors, work together, who we want to build our products for, and the WordPress interpretation of modern, open source best practices.
+The WordPress community welcomes contributors from around the world to help us [Make WordPress](https://make.wordpress.org/) and [Democratize Publishing](https://wordpress.org/about/). The [Contributor Handbook](https://make.wordpress.org/handbook/) aims to express our shared expectations of how we, as contributors, work together, who we want to build our products for, and the WordPress interpretation of modern, open source best practices.
 
 This includes a [Community Code of Conduct](https://make.wordpress.org/handbook/community-code-of-conduct/) (partially included below) and [Incident Response Team](https://make.wordpress.org/community/handbook/irt/).
 


### PR DESCRIPTION
This adds a default Code of Conduct community health file for all repositories under the WordPress organization.